### PR TITLE
feat: Update semantic-release Workflow Permissions

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
-  pull-requests: read
-
 jobs:
   semantic-release:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "bundle exec fastlane android release version:${nextRelease.version} && bundle exec fastlane android firebase notes: '${nextRelease.notes}'"
+        "prepareCmd": "${nextRelease.notes}' > /tmp/release_notes.txt && bundle exec fastlane android release version:${nextRelease.version} && bundle exec fastlane android firebase notes_file:/tmp/release_notes.txt"
       }
     ],
     [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,13 @@ platform :android do
 
   desc "Distribute the release build to Firebase"
   lane :firebase do |options|
-      release_notes = options[:notes] || "Automated release via semantic-release"
+      release_notes = if options[:notes_file] && File.exist?(options[:notes_file])
+                          File.read(options[:notes_file])
+                        elsif options[:notes]
+                          options[:notes]
+                        else
+                          "Automated release via semantic-release"
+                        end
     firebase_app_distribution(
       app: ENV["FIREBASE_APP_ID"],
       testers: ENV["FIREBASE_TESTERS"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release notes are now written during CI and automatically included in Android app distributions.
  * Firebase deployments accept customizable release notes (file or option) with a default fallback message if none provided.
  * CI now logs actor and Git identity info during release jobs to aid debugging and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->