### PR TITLE
ci: Undo Keystore Export Removal

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Decode Keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > app/keystore.jks
 
+      - name: Export keystore path
+        run: echo "KEYSTORE_PATH=$GITHUB_WORKSPACE/app/keystore.jks" >> $GITHUB_ENV
+
       - name: Write keystore.properties
         run: |
           cat <<EOF > keystore.properties

--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "bundle exec fastlane android release version:${nextRelease.version} && bundle exec fastlane android firebase notes:'${nextRelease.notes}'"
+        "prepareCmd": "bundle exec fastlane android release version:${nextRelease.version} && RELEASE_NOTES='${nextRelease.notes}' bundle exec fastlane android firebase"
       }
     ],
     [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,7 @@ platform :android do
 
   desc "Distribute the release build to Firebase"
   lane :firebase do |options|
-      release_notes = options[:notes] || "Automated release via semantic-release"
+    release_notes = ENV["RELEASE_NOTES"] || options[:notes] || "Automated release via semantic-release"
     firebase_app_distribution(
       app: ENV["FIREBASE_APP_ID"],
       testers: ENV["FIREBASE_TESTERS"],


### PR DESCRIPTION
## Ticket
ISSUE - #38

## Rationale
Undo Keystore export removal to fix allow the fastlane to find it to build the release apk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced release workflow authentication by introducing a generated app token and clearer actor logging.
  * Updated release commit identities to reflect project and release automation names.
  * Propagated dynamic release notes through the release pipeline and into the deployment lane.
  * Made deployment step accept environment or runtime-provided release notes for clearer, flexible releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->